### PR TITLE
SHANK-276 Filter blank lines after open braces

### DIFF
--- a/src/main/java/gov/va/jarranger/Jarranger.java
+++ b/src/main/java/gov/va/jarranger/Jarranger.java
@@ -9,14 +9,23 @@ import com.github.javaparser.ast.body.TypeDeclaration;
 import com.github.javaparser.printer.PrettyPrinter;
 import com.github.javaparser.printer.PrettyPrinterConfiguration;
 import com.github.javaparser.utils.SourceRoot;
+import com.google.common.collect.Iterables;
 import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
 import lombok.Builder;
 import lombok.NonNull;
 import lombok.SneakyThrows;
 import lombok.Value;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.maven.plugin.logging.Log;
 
 @Builder
@@ -57,6 +66,30 @@ final class Jarranger {
     return printerConfig;
   }
 
+  @SneakyThrows
+  private static void removeBlankLineAfterOpenBrace(final Path arrangedPath) {
+    final List<String> lines = Files.readAllLines(arrangedPath, StandardCharsets.UTF_8);
+    final List<String> filteredLines = new ArrayList<>(lines.size());
+    boolean filtered = false;
+    for (String line : lines) {
+      if (StringUtils.isBlank(line)
+          && !filteredLines.isEmpty()
+          && Iterables.getLast(filteredLines).trim().endsWith("{")) {
+        filtered = true;
+        continue;
+      }
+      filteredLines.add(line);
+    }
+    if (!filtered) {
+      return;
+    }
+    Files.writeString(
+        arrangedPath,
+        filteredLines.stream().collect(Collectors.joining("\n")),
+        StandardCharsets.UTF_8,
+        StandardOpenOption.TRUNCATE_EXISTING);
+  }
+
   /**
    * Arrange each Java file in the given source directory. This directory corresponds to the root of
    * the package structure, e.g. proj/src/main/java or proj/src/test/java.
@@ -70,7 +103,7 @@ final class Jarranger {
     sourceRoot.setPrinter(new PrettyPrinter(printerConfig())::print);
 
     final AtomicInteger totalCount = new AtomicInteger();
-    final AtomicInteger arrangedCount = new AtomicInteger();
+    final List<Path> arrangedPaths = new CopyOnWriteArrayList<>();
     sourceRoot.parseParallelized(
         (localPath, absolutePath, parseResult) -> {
           log.debug("Processing " + absolutePath);
@@ -94,13 +127,17 @@ final class Jarranger {
           }
 
           log.debug("Arranged " + absolutePath);
-          arrangedCount.incrementAndGet();
+          arrangedPaths.add(absolutePath);
           return SourceRoot.Callback.Result.SAVE;
         });
 
+    for (Path arrangedPath : arrangedPaths) {
+      removeBlankLineAfterOpenBrace(arrangedPath);
+    }
+
     return ArrangementResult.builder()
         .total(totalCount.get())
-        .arranged(arrangedCount.get())
+        .arranged(arrangedPaths.size())
         .build();
   }
 


### PR DESCRIPTION
Suppress the extra blank lines that the JavaParser library inserts after opening curly braces, e.g.
```
  private static Address toAddress(Optional<AddressInfo> eeAddress) {

    if (eeAddress.isEmpty()) {
      return null;
    }
```